### PR TITLE
Add new feature

### DIFF
--- a/xyz/node/agent.py
+++ b/xyz/node/agent.py
@@ -52,6 +52,7 @@ class Agent:
         2. The `flowing()` method must be implemented. This method is the core functionality of the Agent.
         """
 
+        self.llm_agents_dict = dict
         super().__setattr__("type", "agent")
         super().__setattr__("information", dict)
         super().__setattr__("output_type", str)
@@ -88,6 +89,68 @@ class Agent:
         """
         ...
 
+    def set_generate_args(self, llm_agent_name: str = None, **generate_args: dict) -> None:
+        """Set the generate arguments for the llm agent.
+        If the llm_agent_name is None, the function will reset the generate arguments for all llm agents in this agent.
+        If the llm_agent_name is not None, the function will reset the generate arguments for the specific llm agent.
+
+        Parameters
+        ----------
+        llm_agent_name : str, optional
+            The attribute name in this agent, by default None
+            e.g. self.llm_1 = LLMAgent()
+                The llm_agent_name is 'llm_1'
+        generate_args : dict
+            The generate arguments for the llm agent.
+        """
+
+        self.llm_agents_dict = {}
+        # Update the llm agents in this agent.
+        for key, value in vars(self).items():
+            try:
+                if "type" in vars(value) and value.type == "llm_agent":
+                    # noinspection PyProtectedMember
+                    self.llm_agents_dict[key] = value
+            except:
+                pass
+
+        if llm_agent_name:
+            assert llm_agent_name in self.llm_agents_dict, f"The llm agent {llm_agent_name} is not in the agent."
+            self.llm_agents_dict[llm_agent_name].set_generate_args(**generate_args)
+        else:
+            for _name, llm_agent in self.llm_agents_dict.items():
+                llm_agent.set_generate_args(**generate_args)
+
+    def reset_generate_args(self, llm_agent_name: str = None) -> None:
+        """Reset the generate arguments be the same with the OpenAIClient's generate args for the llm agent.
+        If the llm_agent_name is None, the function will reset the generate arguments for all llm agents in this agent.
+        If the llm_agent_name is not None, the function will reset the generate arguments for the specific llm agent.
+
+        Parameters
+        ----------
+        llm_agent_name : str, optional
+            The attribute name in this agent, by default None
+            e.g. self.llm_1 = LLMAgent()
+                The llm_agent_name is 'llm_1'
+        """
+
+        self.llm_agents_dict = {}
+        # Update the llm agents in this agent.
+        for key, value in vars(self).items():
+            try:
+                if "type" in vars(value) and value.type == "llm_agent":
+                    # noinspection PyProtectedMember
+                    self.llm_agents_dict[key] = value
+            except:
+                pass
+
+        if llm_agent_name:
+            assert llm_agent_name in self.llm_agents_dict, f"The llm agent {llm_agent_name} is not in the agent."
+            self.llm_agents_dict[llm_agent_name].reset_generate_args()
+        else:
+            for _name, llm_agent in self.llm_agents_dict.items():
+                llm_agent.reset_generate_args()
+
     def set_information(self, information: dict) -> None:
         """
         Set the information of the agent. And check the format of the information.
@@ -113,7 +176,8 @@ class Agent:
         assert "properties" in information["function"]["parameters"], "The information must have a key 'properties'."
         assert "required" in information["function"]["parameters"], "The information must have a key 'required'."
         for parameter in information["function"]["parameters"]["required"]:
-            assert parameter in information["function"]["parameters"]["properties"], "The required parameter must in properties."
+            assert parameter in information["function"]["parameters"]["properties"], ("The required parameter must in "
+                                                                                      "properties.")
 
         self.information = information
 
@@ -153,10 +217,10 @@ class Agent:
 
         for key, value in vars(self).items():
             try:
-                if "type" in vars(value) and value.type == "agent":
+                if "type" in vars(value) and (value.type == "agent" or value.type == "llm_agent"):
                     # noinspection PyProtectedMember
                     info += f"\n{pre_blank}[SubAgent: {key}: {value._structure(order + 1)}]"
-            except AttributeError:
+            except:
                 pass
 
         return info


### PR DESCRIPTION
Docs:

## Method for Adjusting Agent Generation Parameters

1. We can set parameters through `Agent.set_generate_args()`.
2. We can directly manipulate `LLMAgent.set_generate_args()` to set parameters.
3. We can adjust parameters by operating `OpenAIClient.set_generate_args()`.

### Code Logic:

OpenAI's interface has many parameters that affect the generation results. `OpenAIClient` is set with some generation parameters during initialization. In actual use, we will adjust some parameters for testing:

- Least recommended: Use `OpenAIClient.set_generate_args()`. Reason: A single `OpenAIClient` might be used by multiple `LLMAgent`s, and any changes will affect all `LLMAgent`s.
- Use `Agent.set_generate_args()`:
  - Specify parameters: `llm_agent_name: str` and generation parameters, this will only change the parameters of the corresponding `LLMAgent` within this Agent.
  - Without specifying parameters: `llm_agent_name: str`, this will change the parameters of all `LLMAgent`s within this Agent.

This method will update the dictionary attribute of generation parameters within `LLMAgent`. Each time `OpenAIClient` is requested, it will carry this attribute. `OpenAIClient` will take this dictionary attribute as the standard for this request.

Use internal parameters: `llm_agent_name: str`, the `dict` update method will be used internally to update the generation parameters.

### Core:

There are two variables controlling the generation parameters:

1. `OpenAIClient.generate_args`
2. `LLMAgent.generate_args`

Higher priority: `LLMAgent.generate_args`

### Logic:

- `OpenAIClient.generate_args`: This parameter will be used when requesting the API. If changed, it will affect all places that use this `OpenAIClient`.
- `LLMAgent.generate_args` will be used first when requesting the API each time, and it will not affect other `LLMAgent`s.

## Method for Restoring Default Agent Generation Parameters:

- `OpenAIClient.reset_generate_args()`: Restores the generation parameter settings at the time of instantiation.
- `Agent.set_generate_args()`:
  - Specify parameters: `llm_agent_name: str` and generation parameters, this will reset the generation parameter attribute of the corresponding `LLMAgent` to {}.
  - Without specifying parameters: `llm_agent_name: str`, this will change the generation parameter attribute of all `LLMAgent`s within this Agent to {}.

## LLMAgent.debug()

Add more info, also show the last call API's parameters.

## Commit comments:

* OpenAIClient.set_generate_args()

* {Agent\LLMAgent}.set_generate_args()

* fix a bug of vars() using in Agent

## Description

Allow the user to change the generate args .

## Motivation and Context(Optional)

In the experiments, the user may need different parameters for different LLMAgents. Re-create the OpenAIClient is not very good. We add some methods in Agent, LLMAgent, OpenAIClient to set the parameters.

## How Has This Been Tested?

I have a jupyter-notebook to test each functions.

## Types of Changes

What type of changes does your Pull Request introduce? (Check all that apply)

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing functionality)

## Checklist

- [x] I have read the project's contributing guidelines.
- [x] My code follows the project's coding style.
- [ ] I have written or updated unit tests for the new functionality.
- [x] I have updated the comments in code which is necessary,
- [x] I have rebased all the commit in my git.
- [x] I have updated the documentation as necessary.
- [x] I have added a descriptive commit message with a summary of the changes.
